### PR TITLE
[Firebase Migration] Use `android_channel_id` field

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -205,7 +205,9 @@ public class RNPushNotificationHelper {
                 }
             }
 
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+            String notificationChannelId = bundle.getString("android_channel_id", NOTIFICATION_CHANNEL_ID);
+
+            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, notificationChannelId)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(visibility)


### PR DESCRIPTION
Use `android_channel_id` field in notification data to determine which notification channel to use for delivering noisy push notifications. Or default to the standard hardcoded notification channel ID if the field is not specified.

https://chefsteps.atlassian.net/browse/MOBCOOK-4510